### PR TITLE
V10 fork fixes

### DIFF
--- a/.github/workflows/soup-approval-verification.yml
+++ b/.github/workflows/soup-approval-verification.yml
@@ -1,0 +1,10 @@
+name: SOUP - Approval Verification
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  soups:
+    uses: QuickBirdEng/workflows/.github/workflows/soup-approval-verification-workflow.yml@main
+    secrets: inherit

--- a/.soups/dart/flutter_secure_storage-10.x.x.json
+++ b/.soups/dart/flutter_secure_storage-10.x.x.json
@@ -1,0 +1,108 @@
+{
+  "package": "flutter_secure_storage",
+  "version": "10.x.x",
+  "purpose": "A Flutter plugin to securely store sensitive data in a key-value pair format using platform-specific secure storage solutions. It supports Android, iOS, macOS, Windows, and Linux.",
+  "provider": "QuickBird GmbH",
+  "license": "QuickBird",
+  "urls": {
+    "provider": "https://github.com/QuickBirdEng/flutter_secure_storage",
+    "documentation": "https://github.com/QuickBirdEng/flutter_secure_storage",
+    "known_issues": "https://github.com/QuickBirdEng/flutter_secure_storage/issues"
+  },
+  "requirements": {
+    "grq-1": {
+      "description": "Has a suitable license",
+      "fulfilled": true,
+      "fulfilled_visual": "✅",
+      "reason_if_requirement_not_fulfilled": "",
+      "metadata": {
+        "license": "QuickBird",
+        "license_key": "qb",
+        "license_spdx_id": "BSD-3-Clause",
+        "license_url": "https://github.com/QuickBirdEng/flutter_secure_storage/blob/develop/LICENSE",
+        "compliance_status": "ALLOWED: License 'qb' is in allowed list"
+      }
+    },
+    "grq-2": {
+      "description": "Comprehensive documentation is available",
+      "fulfilled": true,
+      "fulfilled_visual": "✅",
+      "reason_if_requirement_not_fulfilled": "",
+      "metadata": "https://github.com/QuickBirdEng/flutter_secure_storage"
+    },
+    "grq-3": {
+      "description": "Is maintained and support is available",
+      "fulfilled": false,
+      "fulfilled_visual": "❌",
+      "reason_if_requirement_not_fulfilled": "The package is QuickBird's internal package and releases can be provisioned (on demand) when needed.",
+      "metadata": {
+        "analysis_period": "12 months",
+        "releases_found": 1,
+        "min_expected": 2,
+        "recent_versions": {
+          "v10.0.1": "March 10, 2025"
+        }
+      }
+    },
+    "grq-4": {
+      "description": "Does not contain major or critical security issues.",
+      "fulfilled": true,
+      "fulfilled_visual": "✅",
+      "reason_if_requirement_not_fulfilled": "",
+      "metadata": {
+        "package": "flutter_secure_storage",
+        "commit_checked": {
+          "version": "10.0.1",
+          "commit": "c61596586e27ac06c70b2ba2680d15a10fa4c87a"
+        },
+        "vulnerabilities_count": 0,
+        "vulnerabilities": {}
+      }
+    },
+    "grq-5": {
+      "description": "Provider is reliable, trustworthy and communicative",
+      "fulfilled": true,
+      "fulfilled_visual": "✅",
+      "reason_if_requirement_not_fulfilled": "",
+      "metadata": {
+        "stars": 0,
+        "forks": 0,
+        "subscribers": 0,
+        "one_of_following_conditions": {
+          "stars_or_forks_or_subscribers_any_greater_than_or_equal_to_1500": "❌",
+          "sum_of_stars_forks_subscribers_greater_than_or_equal_to_3000": "❌",
+          "self_owned": "✅"
+        }
+      }
+    },
+    "grq-6": {
+      "description": "Conforms to Semantic Versioning",
+      "fulfilled": true,
+      "fulfilled_visual": "✅",
+      "reason_if_requirement_not_fulfilled": "",
+      "metadata": {
+        "total_versions_checked": "1"
+      }
+    },
+    "version-check": {
+      "description": "Is within the latest stable semantic family (Major.X.X or 0.Minor.X)",
+      "fulfilled": true,
+      "fulfilled_visual": "✅",
+      "reason_if_requirement_not_fulfilled": "",
+      "metadata": {
+        "latest_stable": "10.0.1",
+        "latest_stable_tag_url": "https://github.com/QuickBirdEng/flutter_secure_storage/releases/tag/v10.0.1"
+      }
+    }
+  },
+  "metadata": {
+    "created": "2025-11-06T09:29:36Z",
+    "updated": "2025-11-06T09:29:36Z",
+    "input_version": "10.0.1",
+    "approval": {
+      "date": "",
+      "by": "",
+      "condition": ""
+    }
+  }
+}

--- a/flutter_secure_storage/CHANGELOG.md
+++ b/flutter_secure_storage/CHANGELOG.md
@@ -3,6 +3,8 @@
 * [Android] Enabled StrongBox by default, use fallback if it's not available.
 * [Android] Method to check if an Android device supports Strongbox
 * [Android] Use old algorithms as default (migration to AES_GCM_NoPadding is broken and fails)
+* [Android] Create separate instances of FlutterSecureStorage with different configs/options
+* [iOS] Add option to use secure enclave (based on [#989 PR](https://github.com/juliansteenbakker/flutter_secure_storage/pull/989))
 
 ## 10.0.0
 This major release brings significant security improvements, platform updates, and modernization across all supported platforms.

--- a/flutter_secure_storage/CHANGELOG.md
+++ b/flutter_secure_storage/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Fork
+
+* Enabled StrongBox by default, use fallback if it's not available.
+* [Android] Method to check if an Android device supports Strongbox
+
 ## 10.0.0
 This major release brings significant security improvements, platform updates, and modernization across all supported platforms.
 

--- a/flutter_secure_storage/CHANGELOG.md
+++ b/flutter_secure_storage/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [Android] Method to check if an Android device supports Strongbox
 * [Android] Use old algorithms as default (migration to AES_GCM_NoPadding is broken and fails)
 * [Android] Create separate instances of FlutterSecureStorage with different configs/options
+* [Android] Use separate keys for different storage instances
 * [iOS] Add option to use secure enclave (based on [#989 PR](https://github.com/juliansteenbakker/flutter_secure_storage/pull/989))
 
 ## 10.0.0

--- a/flutter_secure_storage/CHANGELOG.md
+++ b/flutter_secure_storage/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Fork
 
-* Enabled StrongBox by default, use fallback if it's not available.
+* [Android] Enabled StrongBox by default, use fallback if it's not available.
 * [Android] Method to check if an Android device supports Strongbox
+* [Android] Use old algorithms as default (migration to AES_GCM_NoPadding is broken and fails)
 
 ## 10.0.0
 This major release brings significant security improvements, platform updates, and modernization across all supported platforms.

--- a/flutter_secure_storage/CHANGELOG.md
+++ b/flutter_secure_storage/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [Android] Enabled StrongBox by default, use fallback if it's not available.
 * [Android] Method to check if an Android device supports Strongbox
 * [Android] Use old algorithms as default (migration to AES_GCM_NoPadding is broken and fails)
+* [Android] Set invalidatedByBiometricEnrollment to false
 * [Android] Create separate instances of FlutterSecureStorage with different configs/options
 * [Android] Use separate keys for different storage instances
 * [iOS] Add option to use secure enclave (based on [#989 PR](https://github.com/juliansteenbakker/flutter_secure_storage/pull/989))

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorage.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorage.java
@@ -1145,6 +1145,7 @@ public class FlutterSecureStorage {
                                 .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
                                 .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
                                 .setKeySize(256).build())
+                .setRequestStrongBoxBacked(true)
                 .build();
         return EncryptedSharedPreferences.create(
                 context,

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorage.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorage.java
@@ -35,7 +35,7 @@ public class FlutterSecureStorage {
 
     private static final String TAG = "FlutterSecureStorage";
     private static final Charset charset = StandardCharsets.UTF_8;
-    private static final String SHARED_PREFERENCES_CONFIG_NAME = "FlutterSecureStorageConfiguration";
+    private static final String SHARED_PREFERENCES_CONFIG_NAME_SUFFIX = "Configuration";
 
     private FlutterSecureStorageConfig config;
     @NonNull
@@ -158,7 +158,7 @@ public class FlutterSecureStorage {
         );
 
         SharedPreferences configSource = context.getSharedPreferences(
-                SHARED_PREFERENCES_CONFIG_NAME,
+                config.getSharedPreferencesName() + SHARED_PREFERENCES_CONFIG_NAME_SUFFIX,
                 Context.MODE_PRIVATE
         );
 

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
@@ -130,6 +130,7 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
 
             if (call.method.equals("isStrongBoxSupported")) {
                 result.success(isStrongBoxAvailable);
+                return;
             }
 
             FlutterSecureStorage secureStorage = initInstance(binding.getApplicationContext());

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
@@ -1,6 +1,7 @@
 package com.it_nomads.fluttersecurestorage;
 
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Looper;
@@ -26,10 +27,12 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
     private FlutterSecureStorage secureStorage;
     private HandlerThread workerThread;
     private Handler workerThreadHandler;
+    private boolean isStrongBoxAvailable;
 
     public void initInstance(BinaryMessenger messenger, Context context) {
         try {
             secureStorage = new FlutterSecureStorage(context);
+            isStrongBoxAvailable = context.getApplicationContext().getPackageManager().hasSystemFeature(PackageManager.FEATURE_STRONGBOX_KEYSTORE);
 
             workerThread = new HandlerThread("com.it_nomads.fluttersecurestorage.worker");
             workerThread.start();
@@ -123,6 +126,11 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
         public void run() {
             Map<String, Object> options = (Map<String, Object>) ((Map<String, Object>) call.arguments).get("options");
             FlutterSecureStorageConfig config = new FlutterSecureStorageConfig(options);
+
+            if (call.method.equals("isStrongBoxSupported")) {
+                result.success(isStrongBoxAvailable);
+                return;
+            }
 
             secureStorage.initialize(config, new SecurePreferencesCallback<>() {
                 @Override

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
@@ -24,30 +24,32 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
 
     private static final String TAG = "FlutterSecureStoragePlugin";
     private MethodChannel channel;
-    private FlutterSecureStorage secureStorage;
     private HandlerThread workerThread;
     private Handler workerThreadHandler;
     private boolean isStrongBoxAvailable;
+    private FlutterPluginBinding binding;
 
-    public void initInstance(BinaryMessenger messenger, Context context) {
+    public FlutterSecureStorage initInstance(Context context) {
         try {
-            secureStorage = new FlutterSecureStorage(context);
-            isStrongBoxAvailable = context.getApplicationContext().getPackageManager().hasSystemFeature(PackageManager.FEATURE_STRONGBOX_KEYSTORE);
-
-            workerThread = new HandlerThread("com.it_nomads.fluttersecurestorage.worker");
-            workerThread.start();
-            workerThreadHandler = new Handler(workerThread.getLooper());
-
-            channel = new MethodChannel(messenger, "plugins.it_nomads.com/flutter_secure_storage");
-            channel.setMethodCallHandler(this);
+            return new FlutterSecureStorage(context);
         } catch (Exception e) {
             Log.e(TAG, "Registration failed", e);
+            return null;
         }
     }
 
     @Override
     public void onAttachedToEngine(FlutterPluginBinding binding) {
-        initInstance(binding.getBinaryMessenger(), binding.getApplicationContext());
+        this.binding = binding;
+
+        isStrongBoxAvailable = binding.getApplicationContext().getApplicationContext().getPackageManager().hasSystemFeature(PackageManager.FEATURE_STRONGBOX_KEYSTORE);
+
+        workerThread = new HandlerThread("com.it_nomads.fluttersecurestorage.worker");
+        workerThread.start();
+        workerThreadHandler = new Handler(workerThread.getLooper());
+
+        channel = new MethodChannel(binding.getBinaryMessenger(), "plugins.it_nomads.com/flutter_secure_storage");
+        channel.setMethodCallHandler(this);
     }
 
     @Override
@@ -59,7 +61,6 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
             channel.setMethodCallHandler(null);
             channel = null;
         }
-        secureStorage = null;
     }
 
     @Override
@@ -70,7 +71,7 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
     }
 
     @SuppressWarnings("unchecked")
-    private String getKeyFromCall(MethodCall call) {
+    private String getKeyFromCall(MethodCall call, FlutterSecureStorage secureStorage) {
         Map<String, Object> arguments = (Map<String, Object>) call.arguments;
         return secureStorage.addPrefixToKey((String) arguments.get("key"));
     }
@@ -129,6 +130,11 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
 
             if (call.method.equals("isStrongBoxSupported")) {
                 result.success(isStrongBoxAvailable);
+            }
+
+            FlutterSecureStorage secureStorage = initInstance(binding.getApplicationContext());
+            if (secureStorage == null) {
+                result.error("Could not initialize FlutterSecureStorage", null, null);
                 return;
             }
 
@@ -138,7 +144,7 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
                     try {
                         switch (call.method) {
                             case "write": {
-                                String key = getKeyFromCall(call);
+                                String key = getKeyFromCall(call, secureStorage);
                                 String value = getValueFromCall(call);
 
                                 if (value != null) {
@@ -150,7 +156,7 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
                                 break;
                             }
                             case "read": {
-                                String key = getKeyFromCall(call);
+                                String key = getKeyFromCall(call, secureStorage);
 
                                 if (secureStorage.containsKey(key)) {
                                     String value = secureStorage.read(key);
@@ -165,14 +171,14 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
                                 break;
                             }
                             case "containsKey": {
-                                String key = getKeyFromCall(call);
+                                String key = getKeyFromCall(call, secureStorage);
 
                                 boolean containsKey = secureStorage.containsKey(key);
                                 result.success(containsKey);
                                 break;
                             }
                             case "delete": {
-                                String key = getKeyFromCall(call);
+                                String key = getKeyFromCall(call, secureStorage);
 
                                 secureStorage.delete(key);
                                 result.success(null);

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/KeyCipherImplementationAES23.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/KeyCipherImplementationAES23.java
@@ -29,11 +29,11 @@ class KeyCipherImplementationAES23 implements KeyCipher {
 
     private static final String TAG = "AESCipher23";
     private static final String KEYSTORE_PROVIDER_ANDROID = "AndroidKeyStore";
-    private static final String SHARED_PREFERENCES_NAME = "FlutterSecureKeyStorage";
-    private static final String SHARED_PREFERENCES_KEY = "KeyStoreIV1";
     private static final int IV_SIZE = 16;
     private static final int KEY_SIZE = 256;
     protected final String keyAlias;
+    protected final String ivStorageKey;
+    protected final String ivStoragePrefsName;
 
     protected final Context context;
     protected final FlutterSecureStorageConfig config;
@@ -42,6 +42,17 @@ class KeyCipherImplementationAES23 implements KeyCipher {
         this.context = context;
         this.config = config;
         keyAlias = createKeyAlias(context);
+
+        // Backward compatibility: use original storage names for default config
+        if ("FlutterSecureStorage".equals(config.getSharedPreferencesName())) {
+            ivStoragePrefsName = "FlutterSecureKeyStorage";
+            ivStorageKey = "KeyStoreIV1";
+        } else {
+            String configId = config.getSharedPreferencesName() + "_" + config.getSharedPreferencesKeyPrefix();
+            ivStoragePrefsName = "FlutterSecureKeyStorage_" + configId;
+            ivStorageKey = "KeyStoreIV1_" + configId;
+        }
+
         KeyStore ks = KeyStore.getInstance(KEYSTORE_PROVIDER_ANDROID);
         ks.load(null);
         Key privateKey = ks.getKey(keyAlias, null);
@@ -61,7 +72,13 @@ class KeyCipherImplementationAES23 implements KeyCipher {
     }
 
     protected String createKeyAlias(Context context) {
-        return context.getPackageName() + ".FlutterSecureStoragePluginKey";
+        // Backward compatibility: use original key name for default config
+        if ("FlutterSecureStorage".equals(config.getSharedPreferencesName())) {
+            return context.getPackageName() + ".FlutterSecureStoragePluginKey";
+        }
+
+        String configId = config.getSharedPreferencesName() + "_" + config.getSharedPreferencesKeyPrefix();
+        return context.getPackageName() + ".FlutterSecureStoragePluginKey_" + configId;
     }
 
     @Override
@@ -70,8 +87,8 @@ class KeyCipherImplementationAES23 implements KeyCipher {
         ks.load(null);
         ks.deleteEntry(keyAlias);
 
-        SharedPreferences preferences = context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE);
-        preferences.edit().remove(SHARED_PREFERENCES_KEY).apply();
+        SharedPreferences preferences = context.getSharedPreferences(ivStoragePrefsName, Context.MODE_PRIVATE);
+        preferences.edit().remove(ivStorageKey).apply();
     }
 
     @Override
@@ -90,8 +107,8 @@ class KeyCipherImplementationAES23 implements KeyCipher {
 
     public Cipher getEncryptionCipher(Context context, Key key) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidAlgorithmParameterException, InvalidKeyException {
         Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
-        SharedPreferences preferences = context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE);
-        String ivBase64 = preferences.getString(SHARED_PREFERENCES_KEY, null);
+        SharedPreferences preferences = context.getSharedPreferences(ivStoragePrefsName, Context.MODE_PRIVATE);
+        String ivBase64 = preferences.getString(ivStorageKey, null);
 
         if (ivBase64 != null) {
             byte[] iv =  Base64.decode(ivBase64, Base64.DEFAULT);
@@ -103,7 +120,7 @@ class KeyCipherImplementationAES23 implements KeyCipher {
 
             byte[] iv = cipher.getIV();
             SharedPreferences.Editor editor = preferences.edit();
-            editor.putString(SHARED_PREFERENCES_KEY,  Base64.encodeToString(iv, Base64.DEFAULT));
+            editor.putString(ivStorageKey,  Base64.encodeToString(iv, Base64.DEFAULT));
             editor.apply();
         }
 

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/KeyCipherImplementationAES23.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/KeyCipherImplementationAES23.java
@@ -184,7 +184,7 @@ class KeyCipherImplementationAES23 implements KeyCipher {
                 configureLegacyAuth(builder);
             }
 
-            builder.setInvalidatedByBiometricEnrollment(true);
+            builder.setInvalidatedByBiometricEnrollment(false);
         } else {
             // Explicitly set to false for clarity (default behavior)
             builder.setUserAuthenticationRequired(false);
@@ -229,7 +229,7 @@ class KeyCipherImplementationAES23 implements KeyCipher {
                         configureLegacyAuth(builder);
                     }
 
-                    builder.setInvalidatedByBiometricEnrollment(true);
+                    builder.setInvalidatedByBiometricEnrollment(false);
                 }
 
                 keyGenerator.init(builder.build());

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/KeyCipherImplementationRSA18.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/KeyCipherImplementationRSA18.java
@@ -41,7 +41,13 @@ class KeyCipherImplementationRSA18 implements KeyCipher {
     }
 
     protected String createKeyAlias() {
-        return context.getPackageName() + ".FlutterSecureStoragePluginKey";
+        // Backward compatibility: use original key name for default config
+        if ("FlutterSecureStorage".equals(config.getSharedPreferencesName())) {
+            return context.getPackageName() + ".FlutterSecureStoragePluginKey";
+        }
+
+        String configId = config.getSharedPreferencesName() + "_" + config.getSharedPreferencesKeyPrefix();
+        return context.getPackageName() + ".FlutterSecureStoragePluginKey_" + configId;
     }
 
     @Override

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/KeyCipherImplementationRSA18.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/KeyCipherImplementationRSA18.java
@@ -5,6 +5,9 @@ import android.content.res.Configuration;
 import android.os.Build;
 import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyProperties;
+import android.security.keystore.StrongBoxUnavailableException;
+
+import androidx.annotation.RequiresApi;
 
 import com.it_nomads.fluttersecurestorage.FlutterSecureStorageConfig;
 
@@ -137,26 +140,38 @@ class KeyCipherImplementationRSA18 implements KeyCipher {
         context.createConfigurationContext(config);
     }
 
+    private AlgorithmParameterSpec getSpec(boolean isStrongBoxBacked) {
+        Calendar start = Calendar.getInstance();
+        Calendar end = Calendar.getInstance();
+        end.add(Calendar.YEAR, 25);
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return makeAlgorithmParameterSpecLegacy(context, start, end);
+        }
+
+        return makeAlgorithmParameterSpec(context, start, end, isStrongBoxBacked);
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.P)
     private void createKeys(Context context) throws Exception {
         final Locale localeBeforeFakingEnglishLocale = Locale.getDefault();
         try {
             setLocale(Locale.ENGLISH);
-            Calendar start = Calendar.getInstance();
-            Calendar end = Calendar.getInstance();
-            end.add(Calendar.YEAR, 25);
 
             KeyPairGenerator kpGenerator = KeyPairGenerator.getInstance(TYPE_RSA, KEYSTORE_PROVIDER_ANDROID);
 
             AlgorithmParameterSpec spec;
 
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-                spec = makeAlgorithmParameterSpecLegacy(context, start, end);
-            } else {
-                spec = makeAlgorithmParameterSpec(context, start, end);
-            }
+            try {
+                spec = getSpec(true);
 
-            kpGenerator.initialize(spec);
-            kpGenerator.generateKeyPair();
+                kpGenerator.initialize(spec);
+                kpGenerator.generateKeyPair();
+            } catch (StrongBoxUnavailableException e) {
+                spec = getSpec(false);
+
+                kpGenerator.initialize(spec);
+                kpGenerator.generateKeyPair();
+            }
         } finally {
             setLocale(localeBeforeFakingEnglishLocale);
         }
@@ -174,7 +189,8 @@ class KeyCipherImplementationRSA18 implements KeyCipher {
                 .build();
     }
 
-    protected AlgorithmParameterSpec makeAlgorithmParameterSpec(Context context, Calendar start, Calendar end) {
+    @RequiresApi(api = Build.VERSION_CODES.M)
+    protected AlgorithmParameterSpec makeAlgorithmParameterSpec(Context context, Calendar start, Calendar end, boolean isStrongBoxBacked) {
         final KeyGenParameterSpec.Builder builder = new KeyGenParameterSpec.Builder(keyAlias, KeyProperties.PURPOSE_DECRYPT | KeyProperties.PURPOSE_ENCRYPT)
                 .setCertificateSubject(new X500Principal("CN=" + keyAlias))
                 .setDigests(KeyProperties.DIGEST_SHA256)
@@ -183,6 +199,9 @@ class KeyCipherImplementationRSA18 implements KeyCipher {
                 .setCertificateSerialNumber(BigInteger.valueOf(1))
                 .setCertificateNotBefore(start.getTime())
                 .setCertificateNotAfter(end.getTime());
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && isStrongBoxBacked) {
+            builder.setIsStrongBoxBacked(true);
+        }
         return builder.build();
     }
 }

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/KeyCipherImplementationRSAOAEP.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/KeyCipherImplementationRSAOAEP.java
@@ -32,7 +32,7 @@ class KeyCipherImplementationRSAOAEP extends KeyCipherImplementationRSA18 {
 
     @RequiresApi(api = Build.VERSION_CODES.M)
     @Override
-    protected AlgorithmParameterSpec makeAlgorithmParameterSpec(Context context, Calendar start, Calendar end) {
+    protected AlgorithmParameterSpec makeAlgorithmParameterSpec(Context context, Calendar start, Calendar end, boolean isStrongBoxBacked) {
         final KeyGenParameterSpec.Builder builder = new KeyGenParameterSpec.Builder(keyAlias, KeyProperties.PURPOSE_DECRYPT | KeyProperties.PURPOSE_ENCRYPT)
                 .setCertificateSubject(new X500Principal("CN=" + keyAlias))
                 .setDigests(KeyProperties.DIGEST_SHA256)
@@ -41,6 +41,9 @@ class KeyCipherImplementationRSAOAEP extends KeyCipherImplementationRSA18 {
                 .setCertificateSerialNumber(BigInteger.valueOf(1))
                 .setCertificateNotBefore(start.getTime())
                 .setCertificateNotAfter(end.getTime());
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && isStrongBoxBacked) {
+            builder.setIsStrongBoxBacked(true);
+        }
         return builder.build();
     }
 

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/KeyCipherImplementationRSAOAEP.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/KeyCipherImplementationRSAOAEP.java
@@ -27,7 +27,13 @@ class KeyCipherImplementationRSAOAEP extends KeyCipherImplementationRSA18 {
 
     @Override
     protected String createKeyAlias() {
-        return context.getPackageName() + ".FlutterSecureStoragePluginKeyOAEP";
+        // Backward compatibility: use original key name for default config
+        if ("FlutterSecureStorage".equals(config.getSharedPreferencesName())) {
+            return context.getPackageName() + ".FlutterSecureStoragePluginKeyOAEP";
+        }
+
+        String configId = config.getSharedPreferencesName() + "_" + config.getSharedPreferencesKeyPrefix();
+        return context.getPackageName() + ".FlutterSecureStoragePluginKeyOAEP_" + configId;
     }
 
     @RequiresApi(api = Build.VERSION_CODES.M)

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/StorageCipherFactory.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/StorageCipherFactory.java
@@ -82,10 +82,10 @@ public class StorageCipherFactory {
         if (algorithm == StorageCipherAlgorithm.AES_GCM_NoPadding) {
             if (isKeyStoreKeyCipher(keyCipher)) {
                 // Use KeyStore-based implementation (biometric/PIN auth capable)
-                return new StorageCipherImplementationAES23(context, keyCipher, cipher);
+                return new StorageCipherImplementationAES23(context, keyCipher, cipher, config);
             } else {
                 // Use RSA-wrapped implementation (standard secure storage)
-                return new StorageCipherImplementationGCM(context, keyCipher, cipher);
+                return new StorageCipherImplementationGCM(context, keyCipher, cipher, config);
             }
         }
 
@@ -93,7 +93,7 @@ public class StorageCipherFactory {
         if (algorithm.storageCipher == null) {
             throw new Exception("No implementation available for algorithm: " + algorithm.name());
         }
-        return algorithm.storageCipher.apply(context, keyCipher, cipher);
+        return algorithm.storageCipher.apply(context, keyCipher, cipher, config);
     }
 
     /**

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/StorageCipherFunction.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/StorageCipherFunction.java
@@ -2,9 +2,11 @@ package com.it_nomads.fluttersecurestorage.ciphers;
 
 import android.content.Context;
 
+import com.it_nomads.fluttersecurestorage.FlutterSecureStorageConfig;
+
 import javax.crypto.Cipher;
 
 @FunctionalInterface
 interface StorageCipherFunction {
-    StorageCipher apply(Context context, KeyCipher keyCipher, Cipher cipher) throws Exception;
+    StorageCipher apply(Context context, KeyCipher keyCipher, Cipher cipher, FlutterSecureStorageConfig config) throws Exception;
 }

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/StorageCipherImplementationAES18.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/StorageCipherImplementationAES18.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.util.Base64;
 
+import com.it_nomads.fluttersecurestorage.FlutterSecureStorageConfig;
+
 import java.security.Key;
 import java.security.SecureRandom;
 import java.security.spec.AlgorithmParameterSpec;
@@ -15,19 +17,29 @@ import javax.crypto.spec.SecretKeySpec;
 public class StorageCipherImplementationAES18 implements StorageCipher {
     private static final int keySize = 16;
     private static final String KEY_ALGORITHM = "AES";
-    private static final String SHARED_PREFERENCES_NAME = "FlutterSecureKeyStorage";
-    private static final String SHARED_PREFERENCES_KEY = "VGhpcyBpcyB0aGUga2V5IGZvciBhIHNlY3VyZSBzdG9yYWdlIEFFUyBLZXkK";
+    private final String sharedPreferencesName;
+    private final String sharedPreferencesKey;
     private final Cipher cipher;
     private final SecureRandom secureRandom;
     private final Key secretKey;
 
-    public StorageCipherImplementationAES18(Context context, KeyCipher rsaCipher, Cipher ignoredStorageCipher) throws Exception {
+    public StorageCipherImplementationAES18(Context context, KeyCipher rsaCipher, Cipher ignoredStorageCipher, FlutterSecureStorageConfig config) throws Exception {
         secureRandom = new SecureRandom();
 
-        SharedPreferences preferences = context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE);
+        // Backward compatibility: use original storage names for default config
+        if ("FlutterSecureStorage".equals(config.getSharedPreferencesName())) {
+            this.sharedPreferencesName = "FlutterSecureKeyStorage";
+            this.sharedPreferencesKey = "VGhpcyBpcyB0aGUga2V5IGZvciBhIHNlY3VyZSBzdG9yYWdlIEFFUyBLZXkK";
+        } else {
+            String configId = config.getSharedPreferencesName() + "_" + config.getSharedPreferencesKeyPrefix();
+            this.sharedPreferencesName = "FlutterSecureKeyStorage_" + configId;
+            this.sharedPreferencesKey = "VGhpcyBpcyB0aGUga2V5IGZvciBhIHNlY3VyZSBzdG9yYWdlIEFFUyBLZXkK_" + configId;
+        }
+
+        SharedPreferences preferences = context.getSharedPreferences(sharedPreferencesName, Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = preferences.edit();
 
-        String aesKey = preferences.getString(SHARED_PREFERENCES_KEY, null);
+        String aesKey = preferences.getString(sharedPreferencesKey, null);
 
         cipher = getCipher();
 
@@ -44,14 +56,14 @@ public class StorageCipherImplementationAES18 implements StorageCipher {
         secretKey = new SecretKeySpec(key, KEY_ALGORITHM);
 
         byte[] encryptedKey = rsaCipher.wrap(secretKey);
-        editor.putString(SHARED_PREFERENCES_KEY, Base64.encodeToString(encryptedKey, Base64.DEFAULT));
+        editor.putString(sharedPreferencesKey, Base64.encodeToString(encryptedKey, Base64.DEFAULT));
         editor.apply();
     }
 
     @Override
     public void deleteKey(Context context) {
-        SharedPreferences preferences = context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE);
-        preferences.edit().remove(SHARED_PREFERENCES_KEY).apply();
+        SharedPreferences preferences = context.getSharedPreferences(sharedPreferencesName, Context.MODE_PRIVATE);
+        preferences.edit().remove(sharedPreferencesKey).apply();
     }
 
     protected Cipher getCipher() throws Exception {

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/StorageCipherImplementationAES23.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/StorageCipherImplementationAES23.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.util.Base64;
 
+import com.it_nomads.fluttersecurestorage.FlutterSecureStorageConfig;
+
 import java.security.Key;
 import java.security.SecureRandom;
 
@@ -17,14 +19,25 @@ public class StorageCipherImplementationAES23 implements StorageCipher {
     private static final int defaultIvSize = 12;
     private static final int AUTHENTICATION_TAG_SIZE = 128;
     private static final String KEY_ALGORITHM = "AES";
-    private static final String SHARED_PREFERENCES_NAME = "FlutterSecureKeyStorage";
-    private static final String KEYSTORE_IV_NAME = "BVGhpcyBpcyB0aGUga2V5IGZvciBhIHNlY3VyZSBzdG9yYWdlIEFFUyBLZXkK";
+    private final String sharedPreferencesName;
+    private final String keystoreIvName;
     private final Cipher cipher;
     private final SecureRandom secureRandom;
     private final Key secretKey;
 
-    public StorageCipherImplementationAES23(Context context, KeyCipher ignoredKeyCipher, Cipher cipher) throws Exception{
+    public StorageCipherImplementationAES23(Context context, KeyCipher ignoredKeyCipher, Cipher cipher, FlutterSecureStorageConfig config) throws Exception{
         secureRandom = new SecureRandom();
+        
+        // Backward compatibility: use original storage names for default config
+        if ("FlutterSecureStorage".equals(config.getSharedPreferencesName())) {
+            this.sharedPreferencesName = "FlutterSecureKeyStorage";
+            this.keystoreIvName = "BVGhpcyBpcyB0aGUga2V5IGZvciBhIHNlY3VyZSBzdG9yYWdlIEFFUyBLZXkK";
+        } else {
+            String configId = config.getSharedPreferencesName() + "_" + config.getSharedPreferencesKeyPrefix();
+            this.sharedPreferencesName = "FlutterSecureKeyStorage_" + configId;
+            this.keystoreIvName = "BVGhpcyBpcyB0aGUga2V5IGZvciBhIHNlY3VyZSBzdG9yYWdlIEFFUyBLZXkK_" + configId;
+        }
+        
         this.secretKey = loadOrGenerateApplicationKey(context, cipher);
         this.cipher = getCipher();
     }
@@ -32,8 +45,8 @@ public class StorageCipherImplementationAES23 implements StorageCipher {
     private SecretKey loadOrGenerateApplicationKey(Context context, Cipher biometricCipher) throws Exception {
         final Cipher cipher = (biometricCipher != null) ? biometricCipher : getCipher();
         assert (cipher != null);
-        SharedPreferences preferences = context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE);
-        String encryptedAppKeyBase64 = preferences.getString(KEYSTORE_IV_NAME, null);
+        SharedPreferences preferences = context.getSharedPreferences(sharedPreferencesName, Context.MODE_PRIVATE);
+        String encryptedAppKeyBase64 = preferences.getString(keystoreIvName, null);
 
         if (encryptedAppKeyBase64 != null) {
             // Decrypt existing key - may throw BadPaddingException, IllegalBlockSizeException if algorithm changed
@@ -48,7 +61,7 @@ public class StorageCipherImplementationAES23 implements StorageCipher {
         byte[] newEncryptedAppKey = cipher.doFinal(appKey);
 
         SharedPreferences.Editor editor = preferences.edit();
-        editor.putString(KEYSTORE_IV_NAME, Base64.encodeToString(newEncryptedAppKey, Base64.DEFAULT));
+        editor.putString(keystoreIvName, Base64.encodeToString(newEncryptedAppKey, Base64.DEFAULT));
         editor.apply();
 
         return secretKey;
@@ -56,8 +69,8 @@ public class StorageCipherImplementationAES23 implements StorageCipher {
 
     @Override
     public void deleteKey(Context context) {
-        SharedPreferences preferences = context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE);
-        preferences.edit().remove(KEYSTORE_IV_NAME).apply();
+        SharedPreferences preferences = context.getSharedPreferences(sharedPreferencesName, Context.MODE_PRIVATE);
+        preferences.edit().remove(keystoreIvName).apply();
     }
 
     protected Cipher getCipher() throws Exception {

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/StorageCipherImplementationGCM.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/StorageCipherImplementationGCM.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.util.Base64;
 
+import com.it_nomads.fluttersecurestorage.FlutterSecureStorageConfig;
+
 import java.security.Key;
 import java.security.SecureRandom;
 import java.security.spec.AlgorithmParameterSpec;
@@ -16,19 +18,29 @@ public class StorageCipherImplementationGCM implements StorageCipher {
     private static final int keySize = 16;
     private static final int AUTHENTICATION_TAG_SIZE = 128;
     private static final String KEY_ALGORITHM = "AES";
-    private static final String SHARED_PREFERENCES_NAME = "FlutterSecureKeyStorage";
-    private static final String SHARED_PREFERENCES_KEY = "AESVGhpcyBpcyB0aGUga2V5IGZvciBhIHNlY3VyZSBzdG9yYWdlIEFFUyBLZXkK";
+    private final String sharedPreferencesName;
+    private final String sharedPreferencesKey;
     private final Cipher cipher;
     private final SecureRandom secureRandom;
     private final Key secretKey;
 
-    public StorageCipherImplementationGCM(Context context, KeyCipher rsaCipher, Cipher ignoredCipher) throws Exception {
+    public StorageCipherImplementationGCM(Context context, KeyCipher rsaCipher, Cipher ignoredCipher, FlutterSecureStorageConfig config) throws Exception {
         secureRandom = new SecureRandom();
 
-        SharedPreferences preferences = context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE);
+        // Backward compatibility: use original storage names for default config
+        if ("FlutterSecureStorage".equals(config.getSharedPreferencesName())) {
+            this.sharedPreferencesName = "FlutterSecureKeyStorage";
+            this.sharedPreferencesKey = "AESVGhpcyBpcyB0aGUga2V5IGZvciBhIHNlY3VyZSBzdG9yYWdlIEFFUyBLZXkK";
+        } else {
+            String configId = config.getSharedPreferencesName() + "_" + config.getSharedPreferencesKeyPrefix();
+            this.sharedPreferencesName = "FlutterSecureKeyStorage_" + configId;
+            this.sharedPreferencesKey = "AESVGhpcyBpcyB0aGUga2V5IGZvciBhIHNlY3VyZSBzdG9yYWdlIEFFUyBLZXkK_" + configId;
+        }
+
+        SharedPreferences preferences = context.getSharedPreferences(sharedPreferencesName, Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = preferences.edit();
 
-        String aesKey = preferences.getString(SHARED_PREFERENCES_KEY, null);
+        String aesKey = preferences.getString(sharedPreferencesKey, null);
 
         cipher = getCipher();
 
@@ -45,14 +57,14 @@ public class StorageCipherImplementationGCM implements StorageCipher {
         secretKey = new SecretKeySpec(key, KEY_ALGORITHM);
 
         byte[] encryptedKey = rsaCipher.wrap(secretKey);
-        editor.putString(SHARED_PREFERENCES_KEY, Base64.encodeToString(encryptedKey, Base64.DEFAULT));
+        editor.putString(sharedPreferencesKey, Base64.encodeToString(encryptedKey, Base64.DEFAULT));
         editor.apply();
     }
 
     @Override
     public void deleteKey(Context context) {
-        SharedPreferences preferences = context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE);
-        preferences.edit().remove(SHARED_PREFERENCES_KEY).apply();
+        SharedPreferences preferences = context.getSharedPreferences(sharedPreferencesName, Context.MODE_PRIVATE);
+        preferences.edit().remove(sharedPreferencesKey).apply();
     }
 
     protected Cipher getCipher() throws Exception {

--- a/flutter_secure_storage/lib/flutter_secure_storage.dart
+++ b/flutter_secure_storage/lib/flutter_secure_storage.dart
@@ -344,6 +344,19 @@ class FlutterSecureStorage {
     });
   }
 
+  /// [aOptions] optional Android options
+  Future<bool> isStrongBoxSupported({
+    AndroidOptions? aOptions,
+  }) async {
+    if (defaultTargetPlatform == TargetPlatform.android) {
+      return _platform.isStrongBoxSupported(
+        options: aOptions?.params ?? this.aOptions.params,
+      );
+    } else {
+      throw UnsupportedError(_unsupportedPlatform);
+    }
+  }
+
   /// Select correct options based on current platform
   Map<String, String> _selectOptions(
     AppleOptions? iOptions,

--- a/flutter_secure_storage/lib/options/android_options.dart
+++ b/flutter_secure_storage/lib/options/android_options.dart
@@ -48,13 +48,13 @@ class AndroidOptions extends Options {
         'Your data will be automatically migrated to custom ciphers on first '
         'access. Remove this parameter - it will be ignored.')
     bool encryptedSharedPreferences = false,
-    bool resetOnError = true,
+    bool resetOnError = false,
     bool migrateOnAlgorithmChange = true,
     bool enforceBiometrics = false,
     KeyCipherAlgorithm keyCipherAlgorithm =
-        KeyCipherAlgorithm.RSA_ECB_OAEPwithSHA_256andMGF1Padding,
+        KeyCipherAlgorithm.RSA_ECB_PKCS1Padding,
     StorageCipherAlgorithm storageCipherAlgorithm =
-        StorageCipherAlgorithm.AES_GCM_NoPadding,
+        StorageCipherAlgorithm.AES_CBC_PKCS7Padding,
     this.sharedPreferencesName,
     this.preferencesKeyPrefix,
     this.biometricPromptTitle,
@@ -80,7 +80,7 @@ class AndroidOptions extends Options {
         'The Jetpack Security library is deprecated by Google. '
         'Remove this parameter - it will be ignored.')
     bool encryptedSharedPreferences = false,
-    bool resetOnError = true,
+    bool resetOnError = false,
     bool migrateOnAlgorithmChange = true,
     bool enforceBiometrics = false,
     this.sharedPreferencesName,
@@ -91,8 +91,8 @@ class AndroidOptions extends Options {
         _resetOnError = resetOnError,
         _migrateOnAlgorithmChange = migrateOnAlgorithmChange,
         _enforceBiometrics = enforceBiometrics,
-        _keyCipherAlgorithm = KeyCipherAlgorithm.AES_GCM_NoPadding,
-        _storageCipherAlgorithm = StorageCipherAlgorithm.AES_GCM_NoPadding;
+        _keyCipherAlgorithm = KeyCipherAlgorithm.RSA_ECB_PKCS1Padding,
+        _storageCipherAlgorithm = StorageCipherAlgorithm.AES_CBC_PKCS7Padding;
 
   /// EncryptedSharedPrefences are only available on API 23 and greater
   final bool _encryptedSharedPreferences;

--- a/flutter_secure_storage/lib/test/test_flutter_secure_storage_platform.dart
+++ b/flutter_secure_storage/lib/test/test_flutter_secure_storage_platform.dart
@@ -52,4 +52,10 @@ class TestFlutterSecureStoragePlatform extends FlutterSecureStoragePlatform {
     required Map<String, String> options,
   }) async =>
       data[key] = value;
+
+  @override
+  Future<bool> isStrongBoxSupported({
+    required Map<String, String> options,
+  }) async =>
+      true;
 }

--- a/flutter_secure_storage/pubspec.yaml
+++ b/flutter_secure_storage/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_secure_storage
 description: A Flutter plugin for securely storing sensitive data using encrypted storage.
-version: 10.0.0
+version: 10.0.0-fork
 repository: https://github.com/mogol/flutter_secure_storage/tree/develop/flutter_secure_storage
 
 environment:
@@ -31,11 +31,31 @@ dependencies:
   # implementation constraints as "any". We cannot do it right now as it fails pub publish
   # validation, so we set a ^ constraint.
   # https://github.com/flutter/flutter/issues/46264
-  flutter_secure_storage_darwin: ^0.2.0
-  flutter_secure_storage_linux: ^3.0.0
-  flutter_secure_storage_platform_interface: ^2.0.1
-  flutter_secure_storage_web: ^2.1.0
-  flutter_secure_storage_windows: ^4.1.0
+  flutter_secure_storage_darwin:
+    git:
+      url: git@github.com:QuickBirdEng/flutter_secure_storage.git
+      path: flutter_secure_storage_darwin
+      ref: v10.0.0-fork
+  flutter_secure_storage_linux:
+    git:
+      url: git@github.com:QuickBirdEng/flutter_secure_storage.git
+      path: flutter_secure_storage_linux
+      ref: v10.0.0-fork
+  flutter_secure_storage_platform_interface:
+    git:
+      url: git@github.com:QuickBirdEng/flutter_secure_storage.git
+      path: flutter_secure_storage_platform_interface
+      ref: v10.0.0-fork
+  flutter_secure_storage_web:
+     git:
+      url: git@github.com:QuickBirdEng/flutter_secure_storage.git
+      path: flutter_secure_storage_web
+      ref: v10.0.0-fork
+  flutter_secure_storage_windows:
+    git:
+      url: git@github.com:QuickBirdEng/flutter_secure_storage.git
+      path: flutter_secure_storage_windows
+      ref: v10.0.0-fork
   meta: ^1.3.0
 
 dev_dependencies:

--- a/flutter_secure_storage_linux/pubspec.yaml
+++ b/flutter_secure_storage_linux/pubspec.yaml
@@ -10,7 +10,11 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_secure_storage_platform_interface: ^2.0.0
+  flutter_secure_storage_platform_interface:
+    git:
+      url: git@github.com:QuickBirdEng/flutter_secure_storage.git
+      path: flutter_secure_storage_platform_interface
+      ref: v10.0.0-fork
 
 flutter:
   plugin:

--- a/flutter_secure_storage_platform_interface/lib/flutter_secure_storage_platform_interface.dart
+++ b/flutter_secure_storage_platform_interface/lib/flutter_secure_storage_platform_interface.dart
@@ -120,4 +120,17 @@ abstract class FlutterSecureStoragePlatform extends PlatformInterface {
   Future<void> deleteAll({
     required Map<String, String> options,
   });
+
+  /// Checks if the android device supports secure hardware-backed storage.
+  ///
+  /// Returns:
+  /// - A [Future] that resolves to `true` if the device supports secure
+  /// hardware-backed storage, or `false` otherwise.
+  Future<bool> isStrongBoxSupported({
+    required Map<String, String> options,
+  }) {
+    throw UnsupportedError(
+      'isStrongBoxSupported() is not available on this platform',
+    );
+  }
 }

--- a/flutter_secure_storage_platform_interface/lib/src/method_channel_flutter_secure_storage.dart
+++ b/flutter_secure_storage_platform_interface/lib/src/method_channel_flutter_secure_storage.dart
@@ -114,4 +114,20 @@ class MethodChannelFlutterSecureStorage extends FlutterSecureStoragePlatform {
         'value': value,
         'options': options,
       });
+
+  @override
+  Future<bool> isStrongBoxSupported({
+    required Map<String, String> options,
+  }) async {
+    if (defaultTargetPlatform != TargetPlatform.android) {
+      throw UnsupportedError('StrongBox is only supported on Android.');
+    }
+    return (await _channel.invokeMethod<bool>(
+          'isStrongBoxSupported',
+          {
+            'options': options,
+          },
+        )) ??
+        false;
+  }
 }

--- a/flutter_secure_storage_web/pubspec.yaml
+++ b/flutter_secure_storage_web/pubspec.yaml
@@ -10,7 +10,11 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_secure_storage_platform_interface: ^2.0.0
+  flutter_secure_storage_platform_interface:
+    git:
+      url: git@github.com:QuickBirdEng/flutter_secure_storage.git
+      path: flutter_secure_storage_platform_interface
+      ref: v10.0.0-fork
   flutter_web_plugins:
     sdk: flutter
   web: ">=0.5.0 <2.0.0"

--- a/flutter_secure_storage_windows/lib/src/flutter_secure_storage_windows_ffi.dart
+++ b/flutter_secure_storage_windows/lib/src/flutter_secure_storage_windows_ffi.dart
@@ -178,6 +178,15 @@ class FlutterSecureStorageWindows extends FlutterSecureStoragePlatform {
       await _backwardCompatible.delete(key: key, options: options);
     }
   }
+
+  @override
+  Future<bool> isStrongBoxSupported({
+    required Map<String, String> options,
+  }) async {
+    throw UnsupportedError(
+      'isStrongBoxSupported() is not available on this platform',
+    );
+  }
 }
 
 /// Creates a custom instance of `FlutterSecureStorageWindows` for testing.

--- a/flutter_secure_storage_windows/lib/src/flutter_secure_storage_windows_stub.dart
+++ b/flutter_secure_storage_windows/lib/src/flutter_secure_storage_windows_stub.dart
@@ -49,6 +49,15 @@ class FlutterSecureStorageWindows extends FlutterSecureStoragePlatform {
   }) =>
       Future.value();
 
+  @override
+  Future<bool> isStrongBoxSupported({
+    required Map<String, String> options,
+  }) async {
+    throw UnsupportedError(
+      'isStrongBoxSupported() is not available on this platform',
+    );
+  }
+
   // @override
   // Future<bool> isCupertinoProtectedDataAvailable() => Future.value(true);
   //

--- a/flutter_secure_storage_windows/pubspec.yaml
+++ b/flutter_secure_storage_windows/pubspec.yaml
@@ -11,7 +11,11 @@ dependencies:
   ffi: ^2.0.0
   flutter:
     sdk: flutter
-  flutter_secure_storage_platform_interface: ^2.0.0
+  flutter_secure_storage_platform_interface:
+    git:
+      url: git@github.com:QuickBirdEng/flutter_secure_storage.git
+      path: flutter_secure_storage_platform_interface
+      ref: v10.0.0-fork
   path: ^1.8.0
   path_provider: ^2.0.0
   win32: ^5.5.4


### PR DESCRIPTION
Attempt to make multiple instances of storage work on Android

Migration is broken (even without any changes to v10.0.0):

```
java.lang.IllegalStateException: Cipher not initialized
	at javax.crypto.Cipher.checkCipherState(Cipher.java:1659)
	at javax.crypto.Cipher.doFinal(Cipher.java:2066)
	at com.it_nomads.fluttersecurestorage.ciphers.StorageCipherImplementationAES23.loadOrGenerateApplicationKey(StorageCipherImplementationAES23.java:61)
	at com.it_nomads.fluttersecurestorage.ciphers.StorageCipherImplementationAES23.<init>(StorageCipherImplementationAES23.java:41)
	at com.it_nomads.fluttersecurestorage.ciphers.StorageCipherFactory.createStorageCipher(StorageCipherFactory.java:85)
	at com.it_nomads.fluttersecurestorage.ciphers.StorageCipherFactory.getCurrentStorageCipher(StorageCipherFactory.java:72)
	at com.it_nomads.fluttersecurestorage.FlutterSecureStorage.migrateNonBiometric(FlutterSecureStorage.java:477)
	at com.it_nomads.fluttersecurestorage.FlutterSecureStorage.migrateData(FlutterSecureStorage.java:355)
	at com.it_nomads.fluttersecurestorage.FlutterSecureStorage.handleKeyMismatch(FlutterSecureStorage.java:843)
	at com.it_nomads.fluttersecurestorage.FlutterSecureStorage.initializeStorageCipher(FlutterSecureStorage.java:268)
	at com.it_nomads.fluttersecurestorage.FlutterSecureStorage.initialize(FlutterSecureStorage.java:258)
	at com.it_nomads.fluttersecurestorage.FlutterSecureStoragePlugin$MethodRunner.run(FlutterSecureStoragePlugin.java:141)
	at android.os.Handler.handleCallback(Handler.java:959)
	at android.os.Handler.dispatchMessage(Handler.java:100)
	at android.os.Looper.loopOnce(Looper.java:232)
	at android.os.Looper.loop(Looper.java:317)
	at android.os.HandlerThread.run(HandlerThread.java:85)
```